### PR TITLE
fix: rename `not-has-type` to `not-kind-eq`

### DIFF
--- a/queries/c/treesitter-outer.scm
+++ b/queries/c/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/cpp/treesitter-outer.scm
+++ b/queries/cpp/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/elixir/treesitter-outer.scm
+++ b/queries/elixir/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/foam/treesitter-outer.scm
+++ b/queries/foam/treesitter-outer.scm
@@ -2,8 +2,8 @@
      (#make-range! "range" @_start @_end))
 
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 ((key_value value: (_)* @_start (_)+ @_end)

--- a/queries/go/treesitter-outer.scm
+++ b/queries/go/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/javascript/treesitter-outer.scm
+++ b/queries/javascript/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/julia/treesitter-outer.scm
+++ b/queries/julia/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (line_comment) @_start . (line_comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "line_comment")
-    (#not-has-type? @head "line_comment")
+    (#not-kind-eq? @tail "line_comment")
+    (#not-kind-eq? @head "line_comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/lua/treesitter-outer.scm
+++ b/queries/lua/treesitter-outer.scm
@@ -4,8 +4,8 @@
 ; TODO: This query doesn't work for comment groups at the start and end of a file
 ;       See: https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/python/treesitter-outer.scm
+++ b/queries/python/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/ruby/treesitter-outer.scm
+++ b/queries/ruby/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/rust/treesitter-outer.scm
+++ b/queries/rust/treesitter-outer.scm
@@ -8,8 +8,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (line_comment) @_start . (line_comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "line_comment")
-    (#not-has-type? @head "line_comment")
+    (#not-kind-eq? @tail "line_comment")
+    (#not-kind-eq? @head "line_comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/tsx/treesitter-outer.scm
+++ b/queries/tsx/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([

--- a/queries/typescript/treesitter-outer.scm
+++ b/queries/typescript/treesitter-outer.scm
@@ -5,8 +5,8 @@
 ; file
 ; See https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
-    (#not-has-type? @tail "comment")
-    (#not-has-type? @head "comment")
+    (#not-kind-eq? @tail "comment")
+    (#not-kind-eq? @head "comment")
     (#make-range! "range" @_start @_end))
 
 (([


### PR DESCRIPTION
Predicate `has-type` is deprecated.
See https://github.com/nvim-treesitter/nvim-treesitter/pull/6716